### PR TITLE
chore(linters): update eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
     "no-constructor-return": ["error"],
     "no-self-compare": ["error"],
     "no-unreachable-loop": ["error"],
-    "multiline-comment-style": ["error", "starred-block"],
     "no-else-return": ["error", { allowElseIf: false }],
     "no-lonely-if": ["error"],
     "no-multi-assign": ["error"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,5 +30,10 @@ module.exports = {
     "no-multi-str": ["error"],
     "require-await": ["error"],
     "spaced-comment": ["error"],
+    "vue/eqeqeq": ["error"],
+    "vue/camelcase": ["error"],
+    "vue/prefer-template": ["warn"],
+    "vue/no-template-target-blank": ["warn"],
+    "vue/no-static-inline-styles": ["warn"],
   },
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

This PR disables the [`multiline-comment-style`](https://eslint.org/docs/rules/multiline-comment-style) core rule to allow any type of comments. Also, it enabled Vue-specific rules for ESLint.

### Why is it needed

Code quality.
