### PR TITLE
chore(ext): prevent recommendation of Vetur

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,5 +7,6 @@
     "EditorConfig.EditorConfig",
     "redhat.vscode-yaml",
     "bradlc.vscode-tailwindcss"
-  ]
+  ],
+  "unwantedRecommendations": ["octref.vetur"]
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

Stop VS Code from recommending [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur), since this is the old extension for Vue 2.

### Why is it needed

Prevent developers from installing the wrong extension.

