### PR TITLE
chore(ide): disable ESLint and Stylelint on save

### DIFF
--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="EslintConfiguration">
     <files-pattern value="{**/*,*}.{html,vue,js}" />
-    <option name="fix-on-save" value="true" />
   </component>
 </project>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,6 @@
   "files.insertFinalNewline": true,
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true,
     "source.fixAll.prettier": true
   },
   "editor.linkedEditing": true,
@@ -13,7 +11,7 @@
   "javascript.preferences.quoteStyle": "double",
   "javascript.referencesCodeLens.enabled": true,
   "eslint.packageManager": "npm",
-  "eslint.validate": ["javascript", "javascriptreact", "vue"],
+  "eslint.validate": ["javascript", "vue"],
   "[html][vue][javascript][json][jsonc][css][markdown][yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

Disabled running ESLint and Stylelint when saving files.

### Why is it needed

Had performance issues with this enabled.
