### PR TITLE
ci(json-server): add workflow to push to fake api repo

### DIFF
--- a/.github/workflows/json-server.yml
+++ b/.github/workflows/json-server.yml
@@ -1,0 +1,25 @@
+name: json-server
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - server/*
+
+jobs:
+  publish:
+    name: 'publish to waw-fake-api repository'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push directory to another repository
+        uses: cpina/github-action-push-to-another-repository@v1.4.2
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: server/
+          destination-github-username: 'Future-Leaders-SI653'
+          destination-repository-name: 'waw-fake-api'
+          user-name: github-actions
+          user-email: github-actions@github.com
+          target-branch: main

--- a/server/db.json
+++ b/server/db.json
@@ -1,5 +1,8 @@
 {
-  "posts": [{ "id": 1, "title": "json-server", "author": "typicode" }],
+  "posts": [
+    { "id": 1, "title": "json-server", "author": "typicode" },
+    { "id": 2, "title": "another post", "author": "dalbitresb12" }
+  ],
   "comments": [{ "id": 1, "body": "some comment", "postId": 1 }],
   "profile": { "name": "typicode" }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

Adds workflow for GitHub Actions to automatically publish changes to the `json-server` files.

### Why is it needed

Having a fake API in production.
