### PR TITLE
fix: update Volar extension id

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "johnsoncodehk.volar",
+    "Vue.volar",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "stylelint.vscode-stylelint",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

I guess they changed their extension id.

### Why is it needed

Fixes a constant error in VS Code.

